### PR TITLE
Implement AJAX dashboard and auth interactions

### DIFF
--- a/main/templates/card_item.html
+++ b/main/templates/card_item.html
@@ -1,5 +1,14 @@
 {% load static %}
-<article class="bg-white/80 backdrop-blur-md rounded-2xl border border-gray-100 hover:shadow-2xl transition-all duration-300 overflow-hidden min-h-[400px] flex flex-col">
+<article
+  class="bg-white/80 backdrop-blur-md rounded-2xl border border-gray-100 hover:shadow-2xl transition-all duration-300 overflow-hidden min-h-[400px] flex flex-col"
+  data-item-id="{{ item.id }}"
+  data-item-name="{{ item.name|escape }}"
+  data-item-description="{{ item.description|default:''|escape }}"
+  data-item-category="{{ item.category|default:''|escape }}"
+  data-item-price="{{ item.price }}"
+  data-item-thumbnail="{{ item.thumbnail|default:''|escape }}"
+  data-item-featured="{{ item.is_featured|yesno:'true,false' }}"
+>
   <!-- Thumbnail -->
   <div class="aspect-[16/9] relative overflow-hidden rounded-t-2xl">
     {% if item.thumbnail %}
@@ -54,12 +63,12 @@
 
       {% if user.is_authenticated and item.user == user %}
         <div class="flex space-x-3">
-          <a href="{% url 'main:edit_item' item.id %}" class="text-gray-500 hover:text-gray-800 text-sm transition-colors">
+          <button type="button" class="text-gray-500 hover:text-gray-800 text-sm transition-colors" data-action="edit" data-id="{{ item.id }}">
             Edit
-          </a>
-          <a href="{% url 'main:delete_item' item.id %}" class="text-red-500 hover:text-red-700 text-sm transition-colors">
+          </button>
+          <button type="button" class="text-red-500 hover:text-red-700 text-sm transition-colors" data-action="delete" data-id="{{ item.id }}">
             Delete
-          </a>
+          </button>
         </div>
       {% endif %}
     </div>

--- a/main/templates/login.html
+++ b/main/templates/login.html
@@ -38,12 +38,12 @@
         </div>
       {% endif %}
 
-      <form method="POST" action="" class="space-y-6">
+      <form id="login-form" method="POST" action="" class="space-y-6">
         {% csrf_token %}
-        
+
         <div>
           <label for="username" class="block text-sm font-medium text-gray-700 mb-2">Username</label>
-          <input 
+          <input
             id="username" 
             name="username" 
             type="text" 
@@ -69,6 +69,8 @@
           Sign In
         </button>
       </form>
+
+      <div id="login-error" class="hidden mt-4 px-4 py-3 rounded-md text-sm border bg-red-50 border-red-200 text-red-700"></div>
 
       <!-- Messages Display -->
       {% if messages %}
@@ -99,7 +101,84 @@
           </a>
         </p>
       </div>
-    </div>
   </div>
+</div>
+
+<div id="toast-container" class="fixed top-20 right-4 z-[60] flex flex-col gap-3"></div>
+
+<script>
+  const loginForm = document.getElementById('login-form');
+  const errorBox = document.getElementById('login-error');
+  const loginButton = loginForm.querySelector('button[type="submit"]');
+
+  function getCsrfToken() {
+    const match = document.cookie.match(/csrftoken=([^;]+)/);
+    return match ? match[1] : '';
+  }
+
+  async function parseJsonResponse(response) {
+    const contentType = response.headers.get('Content-Type') || '';
+    if (contentType.includes('application/json')) {
+      return response.json();
+    }
+    const text = await response.text();
+    throw new Error(text || 'Unexpected server response.');
+  }
+
+  function showToast(message, type = 'info') {
+    const container = document.getElementById('toast-container');
+    const toast = document.createElement('div');
+    toast.className = `flex items-center gap-2 px-4 py-3 rounded-lg shadow-md border text-sm bg-white ${type === 'success' ? 'border-green-200 text-green-700' : type === 'error' ? 'border-red-200 text-red-700' : 'border-slate-200 text-slate-700'}`;
+    toast.textContent = message;
+    container.appendChild(toast);
+    setTimeout(() => {
+      toast.classList.add('opacity-0', 'translate-x-4');
+      setTimeout(() => toast.remove(), 300);
+    }, 2500);
+  }
+
+  loginForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    errorBox.classList.add('hidden');
+    loginButton.disabled = true;
+    loginButton.textContent = 'Signing In...';
+
+    const payload = {
+      username: loginForm.username.value,
+      password: loginForm.password.value,
+    };
+
+    try {
+      const response = await fetch('{% url "main:login" %}', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCsrfToken(),
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await parseJsonResponse(response);
+
+      if (!response.ok) {
+        const errorText = data.errors ? Object.values(data.errors).flat().join(', ') : (data.message || 'Login failed');
+        throw new Error(errorText);
+      }
+
+      showToast('Login successful. Redirecting...', 'success');
+      setTimeout(() => {
+        window.location.href = data.redirect_url || '{% url "main:show_main" %}';
+      }, 800);
+    } catch (error) {
+      errorBox.textContent = error.message;
+      errorBox.classList.remove('hidden');
+      showToast(error.message, 'error');
+    } finally {
+      loginButton.disabled = false;
+      loginButton.textContent = 'Sign In';
+    }
+  });
+</script>
 </div>
 {% endblock content %}

--- a/main/templates/login.html
+++ b/main/templates/login.html
@@ -104,7 +104,7 @@
   </div>
 </div>
 
-<div id="toast-container" class="fixed top-20 right-4 z-[60] flex flex-col gap-3"></div>
+<div id="toast-container" class="fixed top-20 left-1/2 -translate-x-1/2 z-[60] flex flex-col items-center gap-3"></div>
 
 <script>
   const loginForm = document.getElementById('login-form');
@@ -128,12 +128,17 @@
   function showToast(message, type = 'info') {
     const container = document.getElementById('toast-container');
     const toast = document.createElement('div');
-    toast.className = `flex items-center gap-2 px-4 py-3 rounded-lg shadow-md border text-sm bg-white ${type === 'success' ? 'border-green-200 text-green-700' : type === 'error' ? 'border-red-200 text-red-700' : 'border-slate-200 text-slate-700'}`;
+    toast.className = `flex items-center gap-2 px-4 py-3 rounded-lg shadow-md border text-sm bg-white transition-all duration-500 ease-in-out opacity-0 -translate-y-2 ${type === 'success' ? 'border-green-200 text-green-700' : type === 'error' ? 'border-red-200 text-red-700' : 'border-slate-200 text-slate-700'}`;
     toast.textContent = message;
     container.appendChild(toast);
+
+    requestAnimationFrame(() => {
+      toast.classList.remove('opacity-0', '-translate-y-2');
+    });
+
     setTimeout(() => {
-      toast.classList.add('opacity-0', 'translate-x-4');
-      setTimeout(() => toast.remove(), 300);
+      toast.classList.add('opacity-0', '-translate-y-2');
+      setTimeout(() => toast.remove(), 500);
     }, 2500);
   }
 

--- a/main/templates/main.html
+++ b/main/templates/main.html
@@ -7,48 +7,484 @@
 
 {% block content %}
 {% include 'navbar.html' %}
-<div class="bg-gray-50 w-full pt-16 min-h-screen">
-  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
 
-    <div class="mb-8">
-      <h1 class="text-3xl font-bold text-gray-900 mb-2">Available Items</h1>
-      <p class="text-gray-600">Browse and manage your sports items</p>
-    </div>
-
-    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-8 bg-white rounded-lg border border-gray-200 p-4">
-      <div class="flex space-x-3 mb-4 sm:mb-0">
-        <a href="?" class="{% if request.GET.filter == 'all' or not request.GET.filter  %} bg-blue-600 text-white{% else %}bg-white text-gray-700 border border-gray-300{% endif %} px-4 py-2 rounded-md font-medium transition-colors hover:bg-blue-600 hover:text-white">
-          All Items
-        </a>
-        <a href="?filter=my" class="{% if request.GET.filter == 'my' %} bg-blue-600 text-white{% else %}bg-white text-gray-700 border border-gray-300{% endif %} px-4 py-2 rounded-md font-medium transition-colors hover:bg-blue-600 hover:text-white">
-          My Items
-        </a>
-      </div>
-      {% if user.is_authenticated %}
-        <div class="text-sm text-gray-500">
-          Last login: {{ last_login }}
+<div class="bg-gray-50 w-full pt-20 min-h-screen">
+  <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-16">
+    <header class="mb-8">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <p class="text-sm text-slate-500 mb-1">Last login: {{ last_login }}</p>
+          <h1 class="text-3xl font-bold text-slate-900">Welcome back, {{ name|default:user.username }}!</h1>
+          <p class="text-slate-600">Manage all of your football gear in one dashboard.</p>
         </div>
-      {% endif %}
-    </div>
-
-    {% if not item_list %}
-      <div class="bg-white rounded-lg border border-gray-200 p-12 text-center">
-        <div class="w-32 h-32 mx-auto mb-4">
-          <img src="{% static 'image/no-items.png' %}" alt="No items available" class="w-full h-full object-contain">
+        <div class="flex flex-wrap gap-3">
+          <button id="refresh-button" class="flex items-center gap-2 px-4 py-2 bg-white border border-slate-200 rounded-md shadow-sm hover:bg-slate-50 transition">
+            <span>Refresh</span>
+          </button>
+          <button id="create-button" class="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-md shadow hover:bg-blue-700 transition">
+            <span>New Item</span>
+          </button>
         </div>
-        <h3 class="text-lg font-medium text-gray-900 mb-2">No items found</h3>
-        <p class="text-gray-500 mb-6">Be the first to add an item to the marketplace.</p>
-        <a href="{% url 'main:create_items' %}" class="inline-flex items-center px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors">
-          Create Item
-        </a>
       </div>
-    {% else %}
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-        {% for item in item_list %}
-          {% include 'card_item.html' with item=item %}
-        {% endfor %}
+    </header>
+
+    <section class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8" id="stats-wrapper">
+      <article class="stat-card bg-white border border-slate-200 rounded-lg p-5 shadow-sm">
+        <p class="text-sm text-slate-500">Total Items</p>
+        <p class="text-2xl font-semibold text-slate-900" id="stat-total">0</p>
+      </article>
+      <article class="stat-card bg-white border border-slate-200 rounded-lg p-5 shadow-sm">
+        <p class="text-sm text-slate-500">My Items</p>
+        <p class="text-2xl font-semibold text-slate-900" id="stat-my">0</p>
+      </article>
+      <article class="stat-card bg-white border border-slate-200 rounded-lg p-5 shadow-sm">
+        <p class="text-sm text-slate-500">Featured</p>
+        <p class="text-2xl font-semibold text-slate-900" id="stat-featured">0</p>
+      </article>
+      <article class="stat-card bg-white border border-slate-200 rounded-lg p-5 shadow-sm">
+        <p class="text-sm text-slate-500">Most Viewed</p>
+        <p class="text-sm font-medium text-slate-900" id="stat-top">No data</p>
+      </article>
+    </section>
+
+    <section class="bg-white border border-slate-200 rounded-xl shadow-sm">
+      <div class="p-4 border-b border-slate-200 flex flex-col lg:flex-row lg:items-center lg:justify-between gap-3">
+        <div class="flex flex-wrap gap-2" id="filter-buttons">
+          <button data-filter="all" class="filter-btn px-4 py-2 rounded-md border border-slate-200 bg-blue-600 text-white">All Items</button>
+          <button data-filter="my" class="filter-btn px-4 py-2 rounded-md border border-slate-200 bg-white text-slate-700">My Items</button>
+          <button data-filter="featured" class="filter-btn px-4 py-2 rounded-md border border-slate-200 bg-white text-slate-700">Featured</button>
+        </div>
       </div>
-    {% endif %}
+
+      <div class="p-4">
+        <div id="loading-state" class="hidden flex items-center justify-center py-10 text-slate-500">
+          <span class="animate-pulse">Loading items...</span>
+        </div>
+
+        <div id="error-state" class="hidden border border-red-200 bg-red-50 text-red-700 rounded-lg p-4">
+          Something went wrong when loading items. Please try again.
+        </div>
+
+        <div id="empty-state" class="hidden text-center py-12">
+          <div class="w-32 h-32 mx-auto mb-4">
+            <img src="{% static 'image/no-items.png' %}" alt="No items" class="w-full h-full object-contain">
+          </div>
+          <h3 class="text-lg font-semibold text-slate-900 mb-2">No items yet</h3>
+          <p class="text-slate-500 mb-4">Create your first football product to display it here.</p>
+          <button class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition" id="empty-create">Create Item</button>
+        </div>
+
+        <div class="overflow-x-auto">
+          <table class="min-w-full text-left text-sm">
+            <thead class="bg-slate-100 text-slate-600 uppercase text-xs">
+              <tr>
+                <th class="px-4 py-3">Name</th>
+                <th class="px-4 py-3">Category</th>
+                <th class="px-4 py-3">Price</th>
+                <th class="px-4 py-3">Views</th>
+                <th class="px-4 py-3">Featured</th>
+                <th class="px-4 py-3">Actions</th>
+              </tr>
+            </thead>
+            <tbody id="items-table" class="divide-y divide-slate-100"></tbody>
+          </table>
+        </div>
+      </div>
+    </section>
   </div>
 </div>
+
+<div id="item-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-slate-900/70">
+  <div class="bg-white rounded-xl shadow-xl max-w-lg w-full p-6">
+    <div class="flex items-start justify-between mb-4">
+      <div>
+        <h2 id="modal-title" class="text-xl font-semibold text-slate-900">Create Item</h2>
+        <p id="modal-subtitle" class="text-sm text-slate-500">Fill in the details below to save your item.</p>
+      </div>
+      <button id="modal-close" class="text-slate-400 hover:text-slate-600">✕</button>
+    </div>
+
+    <form id="item-form" class="space-y-4">
+      <div>
+        <label for="item-name" class="block text-sm font-medium text-slate-700">Name</label>
+        <input id="item-name" name="name" type="text" required class="mt-1 w-full border border-slate-200 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+      </div>
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label for="item-price" class="block text-sm font-medium text-slate-700">Price</label>
+          <input id="item-price" name="price" type="number" min="0" required class="mt-1 w-full border border-slate-200 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+        </div>
+        <div>
+          <label for="item-category" class="block text-sm font-medium text-slate-700">Category</label>
+          <select id="item-category" name="category" class="mt-1 w-full border border-slate-200 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+            <option value="ball">Ball</option>
+            <option value="shoes">Shoes</option>
+            <option value="shocks">Shocks</option>
+            <option value="jersey">Jersey</option>
+            <option value="other">Other</option>
+          </select>
+        </div>
+      </div>
+      <div>
+        <label for="item-thumbnail" class="block text-sm font-medium text-slate-700">Thumbnail URL</label>
+        <input id="item-thumbnail" name="thumbnail" type="url" placeholder="https://" class="mt-1 w-full border border-slate-200 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+      </div>
+      <div>
+        <label for="item-description" class="block text-sm font-medium text-slate-700">Description</label>
+        <textarea id="item-description" name="description" rows="3" class="mt-1 w-full border border-slate-200 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"></textarea>
+      </div>
+      <div class="flex items-center gap-2">
+        <input id="item-featured" name="is_featured" type="checkbox" class="h-4 w-4 text-blue-600 border-slate-300 rounded">
+        <label for="item-featured" class="text-sm text-slate-700">Mark as featured</label>
+      </div>
+      <div class="flex justify-end gap-3 pt-4 border-t border-slate-200">
+        <button type="button" id="modal-cancel" class="px-4 py-2 rounded-md border border-slate-200 bg-white text-slate-700 hover:bg-slate-50">Cancel</button>
+        <button type="submit" id="modal-submit" class="px-4 py-2 rounded-md bg-blue-600 text-white hover:bg-blue-700">Save Item</button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<div id="delete-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-slate-900/70">
+  <div class="bg-white rounded-xl shadow-xl max-w-sm w-full p-6">
+    <h3 class="text-lg font-semibold text-slate-900 mb-2">Remove this item?</h3>
+    <p class="text-sm text-slate-500">This action cannot be undone.</p>
+    <div class="flex justify-end gap-3 mt-6">
+      <button id="delete-cancel" class="px-4 py-2 rounded-md border border-slate-200 bg-white text-slate-700 hover:bg-slate-50">Cancel</button>
+      <button id="delete-confirm" class="px-4 py-2 rounded-md bg-red-600 text-white hover:bg-red-700">Delete</button>
+    </div>
+  </div>
+</div>
+
+<div id="toast-container" class="fixed top-20 right-4 z-[60] flex flex-col gap-3"></div>
+
+<script>
+  const updateUrlTemplate = "{% url 'main:update_item_ajax' '00000000-0000-0000-0000-000000000000' %}";
+  const deleteUrlTemplate = "{% url 'main:delete_item_ajax' '00000000-0000-0000-0000-000000000000' %}";
+
+  const endpoints = {
+    list: "{% url 'main:items_collection' %}",
+    create: "{% url 'main:create_item_ajax' %}",
+    update: (id) => updateUrlTemplate.replace('00000000-0000-0000-0000-000000000000', id),
+    remove: (id) => deleteUrlTemplate.replace('00000000-0000-0000-0000-000000000000', id),
+    stats: "{% url 'main:item_stats' %}",
+  };
+
+  const filterButtons = document.querySelectorAll('.filter-btn');
+  const refreshButton = document.getElementById('refresh-button');
+  const createButton = document.getElementById('create-button');
+  const emptyCreateButton = document.getElementById('empty-create');
+  const loadingState = document.getElementById('loading-state');
+  const errorState = document.getElementById('error-state');
+  const emptyState = document.getElementById('empty-state');
+  const itemsTable = document.getElementById('items-table');
+  const toastContainer = document.getElementById('toast-container');
+
+  const itemModal = document.getElementById('item-modal');
+  const deleteModal = document.getElementById('delete-modal');
+  const modalTitle = document.getElementById('modal-title');
+  const modalSubtitle = document.getElementById('modal-subtitle');
+  const modalSubmit = document.getElementById('modal-submit');
+  const itemForm = document.getElementById('item-form');
+
+  const nameInput = document.getElementById('item-name');
+  const priceInput = document.getElementById('item-price');
+  const categoryInput = document.getElementById('item-category');
+  const thumbnailInput = document.getElementById('item-thumbnail');
+  const descriptionInput = document.getElementById('item-description');
+  const featuredInput = document.getElementById('item-featured');
+
+  let currentFilter = 'all';
+  let editItemId = null;
+  let deleteItemId = null;
+
+  async function parseJsonResponse(response) {
+    const contentType = response.headers.get('Content-Type') || '';
+    if (contentType.includes('application/json')) {
+      return response.json();
+    }
+    const text = await response.text();
+    throw new Error(text || 'Unexpected server response.');
+  }
+
+  function getCsrfToken() {
+    const match = document.cookie.match(/csrftoken=([^;]+)/);
+    return match ? match[1] : '';
+  }
+
+  function showToast(type, message) {
+    const toast = document.createElement('div');
+    toast.className = `flex items-center gap-2 px-4 py-3 rounded-lg shadow-md border text-sm bg-white ${type === 'success' ? 'border-green-200 text-green-700' : type === 'error' ? 'border-red-200 text-red-700' : 'border-slate-200 text-slate-700'}`;
+    toast.innerHTML = `<span>${message}</span>`;
+    toastContainer.appendChild(toast);
+    setTimeout(() => {
+      toast.classList.add('opacity-0', 'translate-x-4');
+      setTimeout(() => toast.remove(), 300);
+    }, 2500);
+  }
+
+  function formatCurrency(value) {
+    return new Intl.NumberFormat('id-ID', { style: 'currency', currency: 'IDR' }).format(value);
+  }
+
+  function toggleModal(modal, show) {
+    modal.classList.toggle('hidden', !show);
+  }
+
+  function resetForm() {
+    itemForm.reset();
+    featuredInput.checked = false;
+  }
+
+  async function fetchItems() {
+    loadingState.classList.remove('hidden');
+    errorState.classList.add('hidden');
+    emptyState.classList.add('hidden');
+    itemsTable.innerHTML = '';
+
+    try {
+      const response = await fetch(`${endpoints.list}?filter=${currentFilter}`, {
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch items');
+      }
+
+      const data = await parseJsonResponse(response);
+      renderItems(data.data || []);
+    } catch (error) {
+      console.error(error);
+      errorState.classList.remove('hidden');
+    } finally {
+      loadingState.classList.add('hidden');
+    }
+  }
+
+  function renderItems(items) {
+    if (!items.length) {
+      emptyState.classList.remove('hidden');
+      return;
+    }
+
+    emptyState.classList.add('hidden');
+
+    items.forEach((item) => {
+      const row = document.createElement('tr');
+      row.className = 'hover:bg-slate-50 transition';
+      row.dataset.id = item.id;
+      row.dataset.name = item.name;
+      row.dataset.description = item.description || '';
+      row.dataset.category = item.category;
+      row.dataset.price = item.price;
+      row.dataset.thumbnail = item.thumbnail || '';
+      row.dataset.featured = item.is_featured ? 'true' : 'false';
+      row.innerHTML = `
+        <td class="px-4 py-3">
+          <div class="font-medium text-slate-900">${item.name}</div>
+          <p class="text-xs text-slate-500 line-clamp-2">${item.description || 'No description provided.'}</p>
+        </td>
+        <td class="px-4 py-3 capitalize">${item.category}</td>
+        <td class="px-4 py-3">${formatCurrency(item.price)}</td>
+        <td class="px-4 py-3">${item.items_views}</td>
+        <td class="px-4 py-3">
+          <span class="px-2 py-1 rounded-full text-xs font-medium ${item.is_featured ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-500'}">
+            ${item.is_featured ? 'Featured' : 'Standard'}
+          </span>
+        </td>
+        <td class="px-4 py-3">
+          <div class="flex items-center gap-2">
+            <button class="px-3 py-1 text-sm rounded-md border border-slate-200 hover:bg-slate-100 transition" data-action="edit" data-id="${item.id}">Edit</button>
+            <button class="px-3 py-1 text-sm rounded-md border border-red-200 text-red-600 hover:bg-red-50 transition" data-action="delete" data-id="${item.id}">Delete</button>
+          </div>
+        </td>
+      `;
+      itemsTable.appendChild(row);
+    });
+  }
+
+  async function fetchStats() {
+    try {
+      const response = await fetch(endpoints.stats, {
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      });
+      if (!response.ok) {
+        throw new Error('Failed to fetch stats');
+      }
+      const { data } = await parseJsonResponse(response);
+      document.getElementById('stat-total').textContent = data.total_items;
+      document.getElementById('stat-my').textContent = data.my_items;
+      document.getElementById('stat-featured').textContent = data.featured_items;
+      document.getElementById('stat-top').textContent = data.most_viewed ? `${data.most_viewed.name} (${data.most_viewed.items_views} views)` : 'No data';
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
+  async function submitItem(url, method, payload, successMessage) {
+    const response = await fetch(url, {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCsrfToken(),
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    let data;
+    try {
+      data = await parseJsonResponse(response);
+    } catch (error) {
+      throw new Error(error.message || 'Failed to save item');
+    }
+
+    if (!response.ok) {
+      const errors = data.errors ? Object.values(data.errors).flat().join(', ') : data.message || 'Failed to save item';
+      throw new Error(errors);
+    }
+
+    showToast('success', successMessage);
+    toggleModal(itemModal, false);
+    resetForm();
+    await Promise.all([fetchItems(), fetchStats()]);
+  }
+
+  async function deleteItem(id) {
+    const response = await fetch(endpoints.remove(id), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCsrfToken(),
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+      body: JSON.stringify({}),
+    });
+
+    let data;
+    try {
+      data = await parseJsonResponse(response);
+    } catch (error) {
+      throw new Error(error.message || 'Failed to delete item');
+    }
+
+    if (!response.ok) {
+      throw new Error(data.message || 'Failed to delete item');
+    }
+
+    showToast('success', 'Item deleted successfully.');
+    await Promise.all([fetchItems(), fetchStats()]);
+  }
+
+  filterButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      filterButtons.forEach((btn) => {
+        btn.classList.remove('bg-blue-600', 'text-white');
+        btn.classList.add('bg-white', 'text-slate-700');
+      });
+
+      button.classList.remove('bg-white', 'text-slate-700');
+      button.classList.add('bg-blue-600', 'text-white');
+
+      currentFilter = button.dataset.filter;
+      fetchItems();
+    });
+  });
+
+  refreshButton.addEventListener('click', () => {
+    showToast('info', 'Refreshing items...');
+    fetchItems();
+    fetchStats();
+  });
+
+  createButton.addEventListener('click', () => {
+    modalTitle.textContent = 'Create Item';
+    modalSubtitle.textContent = 'Fill in the details below to add a new item.';
+    modalSubmit.textContent = 'Save Item';
+    editItemId = null;
+    resetForm();
+    toggleModal(itemModal, true);
+  });
+
+  if (emptyCreateButton) {
+    emptyCreateButton.addEventListener('click', () => createButton.click());
+  }
+
+  document.getElementById('modal-close').addEventListener('click', () => toggleModal(itemModal, false));
+  document.getElementById('modal-cancel').addEventListener('click', () => toggleModal(itemModal, false));
+
+  document.getElementById('delete-cancel').addEventListener('click', () => toggleModal(deleteModal, false));
+
+  document.getElementById('delete-confirm').addEventListener('click', async () => {
+    if (!deleteItemId) return;
+    try {
+      await deleteItem(deleteItemId);
+    } catch (error) {
+      showToast('error', error.message);
+    } finally {
+      toggleModal(deleteModal, false);
+      deleteItemId = null;
+    }
+  });
+
+  itemForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const payload = {
+      name: nameInput.value,
+      price: Number(priceInput.value),
+      category: categoryInput.value,
+      thumbnail: thumbnailInput.value || '',
+      description: descriptionInput.value || '',
+      is_featured: featuredInput.checked,
+    };
+
+    try {
+      if (editItemId) {
+        await submitItem(endpoints.update(editItemId), 'POST', payload, 'Item updated successfully.');
+      } else {
+        await submitItem(endpoints.create, 'POST', payload, 'Item created successfully.');
+      }
+    } catch (error) {
+      showToast('error', error.message);
+    }
+  });
+
+  itemsTable.addEventListener('click', (event) => {
+    const button = event.target.closest('button');
+    if (!button) return;
+
+    const action = button.dataset.action;
+    const id = button.dataset.id;
+
+    if (action === 'edit') {
+      const row = button.closest('tr');
+      modalTitle.textContent = 'Update Item';
+      modalSubtitle.textContent = 'Make changes to your football item.';
+      modalSubmit.textContent = 'Update Item';
+      editItemId = id;
+
+      nameInput.value = row.dataset.name || '';
+      descriptionInput.value = row.dataset.description || '';
+      categoryInput.value = (row.dataset.category || 'other').toLowerCase();
+      priceInput.value = row.dataset.price || 0;
+      thumbnailInput.value = row.dataset.thumbnail || '';
+      featuredInput.checked = row.dataset.featured === 'true';
+
+      toggleModal(itemModal, true);
+    }
+
+    if (action === 'delete') {
+      deleteItemId = id;
+      toggleModal(deleteModal, true);
+    }
+  });
+
+  window.addEventListener('click', (event) => {
+    if (event.target === itemModal) toggleModal(itemModal, false);
+    if (event.target === deleteModal) toggleModal(deleteModal, false);
+  });
+
+  fetchItems();
+  fetchStats();
+</script>
 {% endblock content %}

--- a/main/templates/main.html
+++ b/main/templates/main.html
@@ -142,7 +142,7 @@
   </div>
 </div>
 
-<div id="toast-container" class="fixed top-20 right-4 z-[60] flex flex-col gap-3"></div>
+<div id="toast-container" class="fixed top-20 left-1/2 -translate-x-1/2 z-[60] flex flex-col items-center gap-3"></div>
 
 <script>
   const updateUrlTemplate = "{% url 'main:update_item_ajax' '00000000-0000-0000-0000-000000000000' %}";
@@ -201,12 +201,17 @@
 
   function showToast(type, message) {
     const toast = document.createElement('div');
-    toast.className = `flex items-center gap-2 px-4 py-3 rounded-lg shadow-md border text-sm bg-white ${type === 'success' ? 'border-green-200 text-green-700' : type === 'error' ? 'border-red-200 text-red-700' : 'border-slate-200 text-slate-700'}`;
+    toast.className = `flex items-center gap-2 px-4 py-3 rounded-lg shadow-md border text-sm bg-white transition-all duration-500 ease-in-out opacity-0 -translate-y-2 ${type === 'success' ? 'border-green-200 text-green-700' : type === 'error' ? 'border-red-200 text-red-700' : 'border-slate-200 text-slate-700'}`;
     toast.innerHTML = `<span>${message}</span>`;
     toastContainer.appendChild(toast);
+
+    requestAnimationFrame(() => {
+      toast.classList.remove('opacity-0', '-translate-y-2');
+    });
+
     setTimeout(() => {
-      toast.classList.add('opacity-0', 'translate-x-4');
-      setTimeout(() => toast.remove(), 300);
+      toast.classList.add('opacity-0', '-translate-y-2');
+      setTimeout(() => toast.remove(), 500);
     }, 2500);
   }
 

--- a/main/templates/main.html
+++ b/main/templates/main.html
@@ -74,21 +74,7 @@
           <button class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition" id="empty-create">Create Item</button>
         </div>
 
-        <div class="overflow-x-auto">
-          <table class="min-w-full text-left text-sm">
-            <thead class="bg-slate-100 text-slate-600 uppercase text-xs">
-              <tr>
-                <th class="px-4 py-3">Name</th>
-                <th class="px-4 py-3">Category</th>
-                <th class="px-4 py-3">Price</th>
-                <th class="px-4 py-3">Views</th>
-                <th class="px-4 py-3">Featured</th>
-                <th class="px-4 py-3">Actions</th>
-              </tr>
-            </thead>
-            <tbody id="items-table" class="divide-y divide-slate-100"></tbody>
-          </table>
-        </div>
+        <div id="items-container" class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-6"></div>
       </div>
     </section>
   </div>
@@ -177,7 +163,7 @@
   const loadingState = document.getElementById('loading-state');
   const errorState = document.getElementById('error-state');
   const emptyState = document.getElementById('empty-state');
-  const itemsTable = document.getElementById('items-table');
+  const itemsContainer = document.getElementById('items-container');
   const toastContainer = document.getElementById('toast-container');
 
   const itemModal = document.getElementById('item-modal');
@@ -197,6 +183,7 @@
   let currentFilter = 'all';
   let editItemId = null;
   let deleteItemId = null;
+  const itemsCache = new Map();
 
   async function parseJsonResponse(response) {
     const contentType = response.headers.get('Content-Type') || '';
@@ -240,7 +227,7 @@
     loadingState.classList.remove('hidden');
     errorState.classList.add('hidden');
     emptyState.classList.add('hidden');
-    itemsTable.innerHTML = '';
+    itemsContainer.innerHTML = '';
 
     try {
       const response = await fetch(`${endpoints.list}?filter=${currentFilter}`, {
@@ -252,7 +239,7 @@
       }
 
       const data = await parseJsonResponse(response);
-      renderItems(data.data || []);
+      renderItems(data);
     } catch (error) {
       console.error(error);
       errorState.classList.remove('hidden');
@@ -261,7 +248,13 @@
     }
   }
 
-  function renderItems(items) {
+  function renderItems(payload) {
+    const items = payload.data || [];
+    const html = payload.html || '';
+
+    itemsCache.clear();
+    items.forEach((item) => itemsCache.set(item.id, item));
+
     if (!items.length) {
       emptyState.classList.remove('hidden');
       return;
@@ -269,38 +262,7 @@
 
     emptyState.classList.add('hidden');
 
-    items.forEach((item) => {
-      const row = document.createElement('tr');
-      row.className = 'hover:bg-slate-50 transition';
-      row.dataset.id = item.id;
-      row.dataset.name = item.name;
-      row.dataset.description = item.description || '';
-      row.dataset.category = item.category;
-      row.dataset.price = item.price;
-      row.dataset.thumbnail = item.thumbnail || '';
-      row.dataset.featured = item.is_featured ? 'true' : 'false';
-      row.innerHTML = `
-        <td class="px-4 py-3">
-          <div class="font-medium text-slate-900">${item.name}</div>
-          <p class="text-xs text-slate-500 line-clamp-2">${item.description || 'No description provided.'}</p>
-        </td>
-        <td class="px-4 py-3 capitalize">${item.category}</td>
-        <td class="px-4 py-3">${formatCurrency(item.price)}</td>
-        <td class="px-4 py-3">${item.items_views}</td>
-        <td class="px-4 py-3">
-          <span class="px-2 py-1 rounded-full text-xs font-medium ${item.is_featured ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-500'}">
-            ${item.is_featured ? 'Featured' : 'Standard'}
-          </span>
-        </td>
-        <td class="px-4 py-3">
-          <div class="flex items-center gap-2">
-            <button class="px-3 py-1 text-sm rounded-md border border-slate-200 hover:bg-slate-100 transition" data-action="edit" data-id="${item.id}">Edit</button>
-            <button class="px-3 py-1 text-sm rounded-md border border-red-200 text-red-600 hover:bg-red-50 transition" data-action="delete" data-id="${item.id}">Delete</button>
-          </div>
-        </td>
-      `;
-      itemsTable.appendChild(row);
-    });
+    itemsContainer.innerHTML = html;
   }
 
   async function fetchStats() {
@@ -449,7 +411,7 @@
     }
   });
 
-  itemsTable.addEventListener('click', (event) => {
+  itemsContainer.addEventListener('click', (event) => {
     const button = event.target.closest('button');
     if (!button) return;
 
@@ -457,18 +419,20 @@
     const id = button.dataset.id;
 
     if (action === 'edit') {
-      const row = button.closest('tr');
       modalTitle.textContent = 'Update Item';
       modalSubtitle.textContent = 'Make changes to your football item.';
       modalSubmit.textContent = 'Update Item';
       editItemId = id;
 
-      nameInput.value = row.dataset.name || '';
-      descriptionInput.value = row.dataset.description || '';
-      categoryInput.value = (row.dataset.category || 'other').toLowerCase();
-      priceInput.value = row.dataset.price || 0;
-      thumbnailInput.value = row.dataset.thumbnail || '';
-      featuredInput.checked = row.dataset.featured === 'true';
+      const item = itemsCache.get(id);
+      if (item) {
+        nameInput.value = item.name || '';
+        descriptionInput.value = item.description || '';
+        categoryInput.value = (item.category || 'other').toLowerCase();
+        priceInput.value = item.price || 0;
+        thumbnailInput.value = item.thumbnail || '';
+        featuredInput.checked = Boolean(item.is_featured);
+      }
 
       toggleModal(itemModal, true);
     }

--- a/main/templates/register.html
+++ b/main/templates/register.html
@@ -117,7 +117,7 @@
   </div>
 </div>
 
-<div id="toast-container" class="fixed top-20 right-4 z-[60] flex flex-col gap-3"></div>
+<div id="toast-container" class="fixed top-20 left-1/2 -translate-x-1/2 z-[60] flex flex-col items-center gap-3"></div>
 
 <script>
   const registerForm = document.getElementById('register-form');
@@ -141,12 +141,17 @@
   function showToast(message, type = 'info') {
     const container = document.getElementById('toast-container');
     const toast = document.createElement('div');
-    toast.className = `flex items-center gap-2 px-4 py-3 rounded-lg shadow-md border text-sm bg-white ${type === 'success' ? 'border-green-200 text-green-700' : type === 'error' ? 'border-red-200 text-red-700' : 'border-slate-200 text-slate-700'}`;
+    toast.className = `flex items-center gap-2 px-4 py-3 rounded-lg shadow-md border text-sm bg-white transition-all duration-500 ease-in-out opacity-0 -translate-y-2 ${type === 'success' ? 'border-green-200 text-green-700' : type === 'error' ? 'border-red-200 text-red-700' : 'border-slate-200 text-slate-700'}`;
     toast.textContent = message;
     container.appendChild(toast);
+
+    requestAnimationFrame(() => {
+      toast.classList.remove('opacity-0', '-translate-y-2');
+    });
+
     setTimeout(() => {
-      toast.classList.add('opacity-0', 'translate-x-4');
-      setTimeout(() => toast.remove(), 300);
+      toast.classList.add('opacity-0', '-translate-y-2');
+      setTimeout(() => toast.remove(), 500);
     }, 2500);
   }
 

--- a/main/templates/register.html
+++ b/main/templates/register.html
@@ -39,9 +39,9 @@
         </div>
       {% endif %}
 
-      <form method="POST" action="" class="space-y-5">
+      <form id="register-form" method="POST" action="" class="space-y-5">
         {% csrf_token %}
-        
+
         <div>
           <label for="username" class="block text-sm font-medium text-gray-700 mb-2">Username</label>
           <input 
@@ -75,12 +75,14 @@
             placeholder="Confirm your password">
         </div>
 
-        <button 
-          type="submit" 
+        <button
+          type="submit"
           class="w-full bg-blue-600 text-white font-medium py-3 px-4 rounded hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition duration-200">
           Create Account
         </button>
       </form>
+
+      <div id="register-error" class="hidden mt-4 px-4 py-3 rounded text-sm border bg-red-50 border-red-200 text-red-700"></div>
 
       {% if messages %}
         <div class="mt-6">
@@ -114,4 +116,82 @@
     </div>
   </div>
 </div>
+
+<div id="toast-container" class="fixed top-20 right-4 z-[60] flex flex-col gap-3"></div>
+
+<script>
+  const registerForm = document.getElementById('register-form');
+  const errorBox = document.getElementById('register-error');
+  const submitButton = registerForm.querySelector('button[type="submit"]');
+
+  function getCsrfToken() {
+    const match = document.cookie.match(/csrftoken=([^;]+)/);
+    return match ? match[1] : '';
+  }
+
+  async function parseJsonResponse(response) {
+    const contentType = response.headers.get('Content-Type') || '';
+    if (contentType.includes('application/json')) {
+      return response.json();
+    }
+    const text = await response.text();
+    throw new Error(text || 'Unexpected server response.');
+  }
+
+  function showToast(message, type = 'info') {
+    const container = document.getElementById('toast-container');
+    const toast = document.createElement('div');
+    toast.className = `flex items-center gap-2 px-4 py-3 rounded-lg shadow-md border text-sm bg-white ${type === 'success' ? 'border-green-200 text-green-700' : type === 'error' ? 'border-red-200 text-red-700' : 'border-slate-200 text-slate-700'}`;
+    toast.textContent = message;
+    container.appendChild(toast);
+    setTimeout(() => {
+      toast.classList.add('opacity-0', 'translate-x-4');
+      setTimeout(() => toast.remove(), 300);
+    }, 2500);
+  }
+
+  registerForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    errorBox.classList.add('hidden');
+    submitButton.disabled = true;
+    submitButton.textContent = 'Creating Account...';
+
+    const payload = {
+      username: registerForm.username.value,
+      password1: registerForm.password1.value,
+      password2: registerForm.password2.value,
+    };
+
+    try {
+      const response = await fetch('{% url "main:register" %}', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCsrfToken(),
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const data = await parseJsonResponse(response);
+
+      if (!response.ok) {
+        const errorText = data.errors ? Object.values(data.errors).flat().join(', ') : (data.message || 'Registration failed');
+        throw new Error(errorText);
+      }
+
+      showToast('Account created successfully. Redirecting to login...', 'success');
+      setTimeout(() => {
+        window.location.href = data.redirect_url || '{% url "main:login" %}';
+      }, 1000);
+    } catch (error) {
+      errorBox.textContent = error.message;
+      errorBox.classList.remove('hidden');
+      showToast(error.message, 'error');
+    } finally {
+      submitButton.disabled = false;
+      submitButton.textContent = 'Create Account';
+    }
+  });
+</script>
 {% endblock content %}

--- a/main/urls.py
+++ b/main/urls.py
@@ -1,5 +1,23 @@
 from django.urls import path
-from main.views import show_main, create_items, show_items, show_xml, show_json, show_xml_by_id, show_json_by_id, register, login_user, logout_user, edit_item, delete_item
+from main.views import (
+    show_main,
+    create_items,
+    show_items,
+    show_xml,
+    show_json,
+    show_xml_by_id,
+    show_json_by_id,
+    register,
+    login_user,
+    logout_user,
+    edit_item,
+    delete_item,
+    items_collection,
+    create_item_ajax,
+    update_item_ajax,
+    delete_item_ajax,
+    item_stats,
+)
 
 app_name = 'main'
 
@@ -11,6 +29,11 @@ urlpatterns = [
     path('json/<str:news_id>/', show_json_by_id, name='show_json_by_id'),
     path('xml/', show_xml, name='show_xml'),
     path('json/', show_json, name='show_json'),
+    path('api/items/', items_collection, name='items_collection'),
+    path('api/items/create/', create_item_ajax, name='create_item_ajax'),
+    path('api/items/<uuid:id>/update/', update_item_ajax, name='update_item_ajax'),
+    path('api/items/<uuid:id>/delete/', delete_item_ajax, name='delete_item_ajax'),
+    path('api/items/stats/', item_stats, name='item_stats'),
     path('register/', register, name='register'),
     path('login/', login_user, name='login'),
     path('logout/', logout_user, name='logout'),

--- a/main/views.py
+++ b/main/views.py
@@ -1,33 +1,44 @@
+import datetime
+import json
+
 from django.shortcuts import render, redirect, get_object_or_404
 from main.models import Item
 from main.forms import ItemForm
-import datetime
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.urls import reverse
 from django.core import serializers
 from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
 from django.contrib import messages
-from django.contrib.auth import authenticate, login, logout
+from django.contrib.auth import login, logout
 from django.contrib.auth.decorators import login_required
+from django.views.decorators.http import require_http_methods
+
+
+def serialize_item(item: Item) -> dict:
+    return {
+        "id": str(item.id),
+        "name": item.name,
+        "price": item.price,
+        "description": item.description,
+        "category": item.category,
+        "thumbnail": item.thumbnail,
+        "is_featured": item.is_featured,
+        "created_at": item.created_at.isoformat() if item.created_at else None,
+        "items_views": item.items_views,
+        "owner": item.user.username if item.user else None,
+    }
 
 
 @login_required(login_url='/login')
 def show_main(request):
-    filter_type = request.GET.get("filter", "all")
-    if filter_type == "all":
-        item_list = Item.objects.all()
-    else:
-        item_list = Item.objects.filter(user=request.user)
-    
     context = {
-        'npm' : '2406361694',
-        'name': 'M Naufal Zhafran Rabiul Batara',
-        'class': 'PBP F',
-        'nama_project': 'ElGasing Football Shop',
-        'item_list': item_list,
-        'last_login': request.COOKIES.get('last_login', 'Never')
+        "npm": "2406361694",
+        "name": "M Naufal Zhafran Rabiul Batara",
+        "class": "PBP F",
+        "nama_project": "ElGasing Football Shop",
+        "last_login": request.COOKIES.get("last_login", "Never"),
     }
-    return render(request, 'main.html', context)
+    return render(request, "main.html", context)
 
 @login_required(login_url='/login')
 def create_items(request):
@@ -66,6 +77,116 @@ def show_json(request):
     return HttpResponse(json_data, content_type="application/json")
 
 
+@login_required(login_url="/login")
+def items_collection(request):
+    filter_type = request.GET.get("filter", "all")
+    queryset = Item.objects.all().order_by("-created_at")
+
+    if filter_type == "my":
+        queryset = queryset.filter(user=request.user)
+    elif filter_type == "featured":
+        queryset = queryset.filter(is_featured=True)
+
+    data = [serialize_item(item) for item in queryset]
+    return JsonResponse({"success": True, "data": data})
+
+
+@login_required(login_url="/login")
+@require_http_methods(["POST"])
+def create_item_ajax(request):
+    if request.headers.get("x-requested-with") != "XMLHttpRequest":
+        return JsonResponse({"success": False, "message": "AJAX request required."}, status=400)
+
+    try:
+        payload = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        return JsonResponse({"success": False, "message": "Invalid JSON payload."}, status=400)
+
+    if isinstance(payload.get("is_featured"), bool):
+        payload["is_featured"] = "on" if payload["is_featured"] else ""
+
+    form = ItemForm(payload)
+
+    if form.is_valid():
+        item = form.save(commit=False)
+        item.user = request.user
+        item.save()
+        return JsonResponse(
+            {
+                "success": True,
+                "message": "Item created successfully.",
+                "data": serialize_item(item),
+            },
+            status=201,
+        )
+
+    return JsonResponse({"success": False, "errors": form.errors}, status=400)
+
+
+@login_required(login_url="/login")
+@require_http_methods(["POST"])
+def update_item_ajax(request, id):
+    if request.headers.get("x-requested-with") != "XMLHttpRequest":
+        return JsonResponse({"success": False, "message": "AJAX request required."}, status=400)
+
+    item = get_object_or_404(Item, pk=id, user=request.user)
+
+    try:
+        payload = json.loads(request.body or "{}")
+    except json.JSONDecodeError:
+        return JsonResponse({"success": False, "message": "Invalid JSON payload."}, status=400)
+
+    if isinstance(payload.get("is_featured"), bool):
+        payload["is_featured"] = "on" if payload["is_featured"] else ""
+
+    form = ItemForm(payload, instance=item)
+
+    if form.is_valid():
+        item = form.save()
+        return JsonResponse(
+            {
+                "success": True,
+                "message": "Item updated successfully.",
+                "data": serialize_item(item),
+            }
+        )
+
+    return JsonResponse({"success": False, "errors": form.errors}, status=400)
+
+
+@login_required(login_url="/login")
+@require_http_methods(["POST"])
+def delete_item_ajax(request, id):
+    if request.headers.get("x-requested-with") != "XMLHttpRequest":
+        return JsonResponse({"success": False, "message": "AJAX request required."}, status=400)
+
+    item = get_object_or_404(Item, pk=id, user=request.user)
+    item.delete()
+    return JsonResponse({"success": True, "message": "Item deleted successfully."})
+
+
+@login_required(login_url="/login")
+def item_stats(request):
+    total_items = Item.objects.count()
+    my_items = Item.objects.filter(user=request.user).count()
+    featured_items = Item.objects.filter(is_featured=True).count()
+    latest_item = Item.objects.filter(user=request.user).order_by("-created_at").first()
+    most_viewed = Item.objects.order_by("-items_views").first()
+
+    return JsonResponse(
+        {
+            "success": True,
+            "data": {
+                "total_items": total_items,
+                "my_items": my_items,
+                "featured_items": featured_items,
+                "latest_item": serialize_item(latest_item) if latest_item else None,
+                "most_viewed": serialize_item(most_viewed) if most_viewed else None,
+            },
+        }
+    )
+
+
 def show_xml_by_id(request, news_id):
    try:
        Item_item = Item.objects.filter(pk=news_id)
@@ -87,37 +208,93 @@ def show_json_by_id(request, news_id):
 def register(request):
     form = UserCreationForm()
 
-    if request.method == "POST":
+    if request.method == "POST" and request.headers.get("x-requested-with") == "XMLHttpRequest":
+        try:
+            payload = json.loads(request.body or "{}")
+        except json.JSONDecodeError:
+            return JsonResponse({"success": False, "message": "Invalid JSON payload."}, status=400)
+
+        form = UserCreationForm(payload)
+        if form.is_valid():
+            form.save()
+            return JsonResponse(
+                {
+                    "success": True,
+                    "message": "Your account has been successfully created!",
+                    "redirect_url": reverse("main:login"),
+                },
+                status=201,
+            )
+
+        return JsonResponse({"success": False, "errors": form.errors}, status=400)
+
+    elif request.method == "POST":
         form = UserCreationForm(request.POST)
         if form.is_valid():
             form.save()
-            messages.success(request, 'Your account has been successfully created!')
-            return redirect('main:login')
-    context = {'form':form}
-    return render(request, 'register.html', context)
+            messages.success(request, "Your account has been successfully created!")
+            return redirect("main:login")
+
+    context = {"form": form}
+    return render(request, "register.html", context)
 
 
 def login_user(request):
-   if request.method == 'POST':
-      form = AuthenticationForm(data=request.POST)
+    if request.method == "POST" and request.headers.get("x-requested-with") == "XMLHttpRequest":
+        try:
+            payload = json.loads(request.body or "{}")
+        except json.JSONDecodeError:
+            return JsonResponse({"success": False, "message": "Invalid JSON payload."}, status=400)
 
-      if form.is_valid():
-        user = form.get_user()
-        login(request, user)
-        response = HttpResponseRedirect(reverse("main:show_main"))
-        response.set_cookie('last_login', str(datetime.datetime.now()))
-        return response
+        form = AuthenticationForm(request, data=payload)
 
-   else:
-      form = AuthenticationForm(request)
-   context = {'form': form}
-   return render(request, 'login.html', context)
+        if form.is_valid():
+            user = form.get_user()
+            login(request, user)
+            response = JsonResponse(
+                {
+                    "success": True,
+                    "message": "Welcome back!",
+                    "redirect_url": reverse("main:show_main"),
+                }
+            )
+            response.set_cookie("last_login", str(datetime.datetime.now()))
+            return response
+
+        return JsonResponse({"success": False, "errors": form.errors}, status=400)
+
+    if request.method == "POST":
+        form = AuthenticationForm(request, data=request.POST)
+
+        if form.is_valid():
+            user = form.get_user()
+            login(request, user)
+            response = HttpResponseRedirect(reverse("main:show_main"))
+            response.set_cookie("last_login", str(datetime.datetime.now()))
+            return response
+    else:
+        form = AuthenticationForm(request)
+
+    context = {"form": form}
+    return render(request, "login.html", context)
 
 
 def logout_user(request):
+    if request.method == "POST" and request.headers.get("x-requested-with") == "XMLHttpRequest":
+        logout(request)
+        response = JsonResponse(
+            {
+                "success": True,
+                "message": "You have been signed out.",
+                "redirect_url": reverse("main:login"),
+            }
+        )
+        response.delete_cookie("last_login")
+        return response
+
     logout(request)
-    response = HttpResponseRedirect(reverse('main:login'))
-    response.delete_cookie('last_login')
+    response = HttpResponseRedirect(reverse("main:login"))
+    response.delete_cookie("last_login")
     return response
 
 

--- a/main/views.py
+++ b/main/views.py
@@ -12,6 +12,7 @@ from django.contrib import messages
 from django.contrib.auth import login, logout
 from django.contrib.auth.decorators import login_required
 from django.views.decorators.http import require_http_methods
+from django.template.loader import render_to_string
 
 
 def serialize_item(item: Item) -> dict:
@@ -88,7 +89,12 @@ def items_collection(request):
         queryset = queryset.filter(is_featured=True)
 
     data = [serialize_item(item) for item in queryset]
-    return JsonResponse({"success": True, "data": data})
+    html = "".join(
+        render_to_string("card_item.html", {"item": item}, request=request)
+        for item in queryset
+    )
+
+    return JsonResponse({"success": True, "data": data, "html": html})
 
 
 @login_required(login_url="/login")

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -66,5 +66,12 @@
 .form-style input[type="checkbox"]:focus {
     outline: none;
     border-color: #1D4ED8;
-    box-shadow: none; 
+    box-shadow: none;
+}
+
+.line-clamp-2 {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
 }

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -79,7 +79,7 @@
     if (!container) {
       container = document.createElement('div');
       container.id = 'toast-container';
-      container.className = 'fixed top-20 right-4 z-[60] flex flex-col gap-3';
+      container.className = 'fixed top-20 left-1/2 -translate-x-1/2 z-[60] flex flex-col items-center gap-3';
       document.body.appendChild(container);
     }
     return container;
@@ -88,12 +88,15 @@
   function showNavToast(message, type = 'info') {
     const container = ensureToastContainer();
     const toast = document.createElement('div');
-    toast.className = `flex items-center gap-2 px-4 py-3 rounded-lg shadow-md border text-sm bg-white ${type === 'success' ? 'border-green-200 text-green-700' : type === 'error' ? 'border-red-200 text-red-700' : 'border-slate-200 text-slate-700'}`;
+    toast.className = `flex items-center gap-2 px-4 py-3 rounded-lg shadow-md border text-sm bg-white transition-all duration-500 ease-in-out opacity-0 -translate-y-2 ${type === 'success' ? 'border-green-200 text-green-700' : type === 'error' ? 'border-red-200 text-red-700' : 'border-slate-200 text-slate-700'}`;
     toast.textContent = message;
     container.appendChild(toast);
+    requestAnimationFrame(() => {
+      toast.classList.remove('opacity-0', '-translate-y-2');
+    });
     setTimeout(() => {
-      toast.classList.add('opacity-0', 'translate-x-4');
-      setTimeout(() => toast.remove(), 300);
+      toast.classList.add('opacity-0', '-translate-y-2');
+      setTimeout(() => toast.remove(), 500);
     }, 2000);
   }
 

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -10,14 +10,11 @@
 
     <!-- Menu -->
     <ul id="nav-menu" class="hidden md:flex flex-col md:flex-row md:items-center gap-4 w-full md:w-auto mt-3 md:mt-0">
-      <li><a href="/" class="hover:text-blue-400">Home</a></li>
-      <li><a href="{% url 'main:create_items' %}" class="hover:text-blue-400">Create Items</a></li>
-
       {% if user.is_authenticated %}
         <li class="md:hidden border-t border-slate-700 pt-2 mt-2">
           <p class="text-sm">Welcome, {{ name|default:user.username }}</p>
           <p class="text-xs">{{ npm|default:"Student" }} - {{ class|default:"Class" }}</p>
-          <a href="{% url 'main:logout' %}" class="block mt-2 bg-red-600 hover:bg-red-700 px-3 py-1 rounded text-sm text-center">Logout</a>
+          <button data-logout-button class="w-full mt-2 bg-red-600 hover:bg-red-700 px-3 py-1 rounded text-sm text-center">Logout</button>
         </li>
       {% else %}
         <li class="md:hidden border-t border-slate-700 pt-2 mt-2 flex gap-2">
@@ -41,9 +38,7 @@
             <p class="font-semibold">Welcome, {{ name|default:user.username }}</p>
             <p class="text-xs">{{ npm|default:"Student" }} - {{ class|default:"Class" }}</p>
           </div>
-          <a href="{% url 'main:logout' %}" class="block px-4 py-2 text-sm hover:bg-red-500 hover:text-white">
-            Logout
-          </a>
+          <button data-logout-button class="block w-full text-left px-4 py-2 text-sm hover:bg-red-500 hover:text-white">Logout</button>
         </div>
       </div>
     {% else %}
@@ -71,4 +66,73 @@
       }
     });
   }
+
+  const logoutButtons = document.querySelectorAll('[data-logout-button]');
+
+  function getCsrfToken() {
+    const match = document.cookie.match(/csrftoken=([^;]+)/);
+    return match ? match[1] : '';
+  }
+
+  function ensureToastContainer() {
+    let container = document.getElementById('toast-container');
+    if (!container) {
+      container = document.createElement('div');
+      container.id = 'toast-container';
+      container.className = 'fixed top-20 right-4 z-[60] flex flex-col gap-3';
+      document.body.appendChild(container);
+    }
+    return container;
+  }
+
+  function showNavToast(message, type = 'info') {
+    const container = ensureToastContainer();
+    const toast = document.createElement('div');
+    toast.className = `flex items-center gap-2 px-4 py-3 rounded-lg shadow-md border text-sm bg-white ${type === 'success' ? 'border-green-200 text-green-700' : type === 'error' ? 'border-red-200 text-red-700' : 'border-slate-200 text-slate-700'}`;
+    toast.textContent = message;
+    container.appendChild(toast);
+    setTimeout(() => {
+      toast.classList.add('opacity-0', 'translate-x-4');
+      setTimeout(() => toast.remove(), 300);
+    }, 2000);
+  }
+
+  async function parseJsonResponse(response) {
+    const contentType = response.headers.get('Content-Type') || '';
+    if (contentType.includes('application/json')) {
+      return response.json();
+    }
+    const text = await response.text();
+    throw new Error(text || 'Unexpected server response.');
+  }
+
+  logoutButtons.forEach((button) => {
+    button.addEventListener('click', async (event) => {
+      event.preventDefault();
+      try {
+        const response = await fetch('{% url "main:logout" %}', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': getCsrfToken(),
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          body: JSON.stringify({}),
+        });
+
+        const data = await parseJsonResponse(response);
+
+        if (!response.ok) {
+          throw new Error(data.message || 'Failed to log out');
+        }
+
+        showNavToast('Logged out successfully.', 'success');
+        setTimeout(() => {
+          window.location.href = data.redirect_url || '{% url "main:login" %}';
+        }, 800);
+      } catch (error) {
+        showNavToast(error.message, 'error');
+      }
+    });
+  });
 </script>


### PR DESCRIPTION
## Summary
- replace the main dashboard with an AJAX-driven table, modal forms, delete confirmation, status indicators, and toast notifications
- expose JSON endpoints for listing, creating, updating, deleting items and for fetching dashboard statistics, plus add AJAX handling to auth views
- update login, register, and navbar UIs to submit via fetch with CSRF protection, inline feedback, and consistent toast messaging

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_68e098939848832b87d314907db043cf